### PR TITLE
Ajout de pages de redirections sur chaque anciennes pages du site

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1;url=http://arpl.fr">
+        <script type="text/javascript">
+            window.location.href = "http://arpl.fr"
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+        If you are not redirected automatically, follow the <a href='http://arpl.fr'>link to ARPL new website.</a>
+    </body>
+</html>

--- a/team.html
+++ b/team.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1;url=http://arpl.fr">
+        <script type="text/javascript">
+            window.location.href = "http://arpl.fr"
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+        If you are not redirected automatically, follow the <a href='http://arpl.fr'>link to ARPL new website.</a>
+    </body>
+</html>


### PR DESCRIPTION
La publication auto ne supprime pas les fichiers du serveur.
Si un fichier HTML n'est plus utilité, plutôt que le supprimer, il faut le remplacer par une redirection permanente.
En ce qui concerne les autres type de fichiers (images, CSS, etc), il sera nécessaire d'aller les retirer soit même, via par exemple un client FTP.

J'ai donc rajouté contact.html et team.html qui sont des anciennes pages du site.